### PR TITLE
update for vulkano 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui_vulkano"
 version = "0.1.0"
-authors = ["derivator <derivator@users.noreply.github.com>"]
+authors = ["derivator <derivator@users.noreply.github.com>", "Arc-blroth <45273859+Arc-blroth@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"
 description = "Vulkano graphics backend for egui"
 homepage = "https://github.com/derivator/egui_vulkano"
@@ -11,14 +11,14 @@ categories = ["gui", "game-development"]
 edition = "2018"
 
 [dependencies]
-vulkano = "0.22.0"
-vulkano-shaders = "0.22.0"
-egui = "0.11.0"
-epaint = "0.11.0"
+vulkano = "0.24.0"
+vulkano-shaders = "0.24.0"
+egui = "0.13.0"
+epaint = "0.13.0"
 thiserror = "1.0"
 
 [dev-dependencies]
-winit = "0.24.0"
-vulkano-win = "0.22.0"
-egui_winit_platform = "0.6.0"
-egui_demo_lib = "0.11.0"
+winit = "0.25.0"
+vulkano-win = "0.24.0"
+egui_winit_platform = "0.9.0"
+egui_demo_lib = "0.13.0"


### PR DESCRIPTION
Hello, I came to your library from egui's readme, but found it requires vulkano v0.22 even though they've moved to v0.23. Then I noticed a fork of your library, and found the author had made the changes necessary to use with vulkano 0.23, tested it for myself and found it works!

Would you accept the patch and update your library? Being able to use the crates.io version would be convenient!

Thanks to both you and @Arc-blroth